### PR TITLE
添加开屏超时时间设置

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,34 +34,10 @@
 ## 入门使用
 ### 引入依赖
 
-- 版本约定
-  * 1.x.x 是非 Null Safety 版本，对应 master 分支
-  * 2.x.x 是 Null Safety 版本，对应 2x 分支
-
-  > 现在阶段会同时维护这 2 个版本，再往后可能仅维护一个空安全版本
-
-- Pub 引入
-
 ``` Dart
 dependencies:
   flutter_qq_ads: ^1.1.1 # 非 Null Safety 版本
   flutter_qq_ads: ^2.1.1 # Null Safety 版本
-```
-
-- Git 引入
-
-``` Dart
-flutter_qq_ads:
-  git: 
-    url: git@github.com:FlutterAds/flutter_qq_ads.git
-    ref: master
-```
-
-- 克隆后本地引入
-
-``` Dart
-flutter_qq_ads:
-  path: [与主项目的相对路径 | 插件的绝对路径]
 ```
 
 ### 初始化广告
@@ -70,37 +46,6 @@ flutter_qq_ads:
 /// [appId] 应用媒体ID
 FlutterQqAds.initAd(appId);
 ```
-### 设置广告事件监听
-
-``` Dart
-FlutterQqAds.onEventListener((event) {
-  // 普通广告事件
-  String _adEvent = 'adId:${event.adId} action:${event.action}';
-  if (event is AdErrorEvent) {
-    // 错误事件
-    _adEvent += ' errCode:${event.errCode} errMsg:${event.errMsg}';
-  } else if (event is AdRewardEvent) {
-    // 激励事件
-    _adEvent +=
-        ' transId:${event.transId} customData:${event.customData} userId:${event.userId}';
-  }
-  print('onEventListener:$_adEvent');
-});
-```
-### 事件列表
-|事件|说明|
-|-|-|
-|onAdLoaded|广告加载成功|
-|onAdPresent|广告填充|
-|onAdExposure|广告曝光|
-|onAdClosed|广告关闭（开屏计时结束或者用户点击关闭）|
-|onAdClicked|广告点击|
-|onAdSkip|广告跳过|
-|onAdComplete|广告播放或计时完毕|
-|onAdError|广告错误|
-|onAdReward|获得广告激励|
-
-> 这里做了统一的抽象，iOS 和 Android 原生 SDK 名称不同，如果觉得对应不上，可以提 [Issues](https://github.com/FlutterAds/flutter_qq_ads/issues)（一定要加上 log 截图）
 ### 开屏广告
 
 - 半屏广告 + Logo
@@ -108,7 +53,12 @@ FlutterQqAds.onEventListener((event) {
 ``` Dart
 /// [posId] 广告位 id
 /// [logo] 如果传值则展示底部logo，不传不展示，则全屏展示
-FlutterQqAds.showSplashAd(posId, 'flutterads_logo');
+/// [fetchDelay] 拉取广告的超时时间，默认值 3 秒，取值范围[1.5~5]秒
+FlutterQqAds.showSplashAd(
+    AdsConfig.splashId,
+    logo: 'flutterads_logo',
+    fetchDelay: 3,
+  );
 ```
 - [Logo 设置的最佳实践](https://github.com/FlutterAds/flutter_qq_ads/blob/develop/doc/SETTING_LOGO.md)
 
@@ -170,6 +120,38 @@ FlutterQqAds.showRewardVideoAd(
     userId: 'userId',
   );
 ```
+
+### 设置广告事件监听
+
+``` Dart
+FlutterQqAds.onEventListener((event) {
+  // 普通广告事件
+  String _adEvent = 'adId:${event.adId} action:${event.action}';
+  if (event is AdErrorEvent) {
+    // 错误事件
+    _adEvent += ' errCode:${event.errCode} errMsg:${event.errMsg}';
+  } else if (event is AdRewardEvent) {
+    // 激励事件
+    _adEvent +=
+        ' transId:${event.transId} customData:${event.customData} userId:${event.userId}';
+  }
+  print('onEventListener:$_adEvent');
+});
+```
+### 事件列表
+|事件|说明|
+|-|-|
+|onAdLoaded|广告加载成功|
+|onAdPresent|广告填充|
+|onAdExposure|广告曝光|
+|onAdClosed|广告关闭（开屏计时结束或者用户点击关闭）|
+|onAdClicked|广告点击|
+|onAdSkip|广告跳过|
+|onAdComplete|广告播放或计时完毕|
+|onAdError|广告错误|
+|onAdReward|获得广告激励|
+
+> 这里做了统一的抽象，iOS 和 Android 原生 SDK 名称不同，如果觉得对应不上，可以提 [Issues](https://github.com/FlutterAds/flutter_qq_ads/issues)（一定要加上 log 截图）
 ## 其他配置
 ### 信任HTTP请求
 苹果公司在iOS9中升级了应用网络通信安全策略，默认推荐开发者使用HTTPS协议来进行网络通信，并限制HTTP协议的请求。为了避免出现无法拉取到广告的情况，我们推荐开发者在info.plist文件中增加如下配置来实现广告的网络访问

--- a/android/src/main/java/com/zero/flutter_qq_ads/PluginDelegate.java
+++ b/android/src/main/java/com/zero/flutter_qq_ads/PluginDelegate.java
@@ -146,7 +146,7 @@ public class PluginDelegate implements MethodChannel.MethodCallHandler, EventCha
     public void showSplashAd(MethodCall call, MethodChannel.Result result) {
         String posId = call.argument(KEY_POSID);
         String logo = call.argument(KEY_LOGO);
-        int fetchDelay = call.argument(KEY_FETCH_DELAY);
+        double fetchDelay = call.argument(KEY_FETCH_DELAY);
         Intent intent = new Intent(activity, AdSplashActivity.class);
         intent.putExtra(KEY_POSID, posId);
         intent.putExtra(KEY_LOGO, logo);

--- a/android/src/main/java/com/zero/flutter_qq_ads/PluginDelegate.java
+++ b/android/src/main/java/com/zero/flutter_qq_ads/PluginDelegate.java
@@ -39,6 +39,8 @@ public class PluginDelegate implements MethodChannel.MethodCallHandler, EventCha
     public static final String KEY_POSID = "posId";
     // logo 参数
     public static final String KEY_LOGO = "logo";
+    // fetchDelay 参数
+    public static final String KEY_FETCH_DELAY = "fetchDelay";
 
     /**
      * 插件代理构造函数构造函数
@@ -144,9 +146,11 @@ public class PluginDelegate implements MethodChannel.MethodCallHandler, EventCha
     public void showSplashAd(MethodCall call, MethodChannel.Result result) {
         String posId = call.argument(KEY_POSID);
         String logo = call.argument(KEY_LOGO);
+        int fetchDelay = call.argument(KEY_FETCH_DELAY);
         Intent intent = new Intent(activity, AdSplashActivity.class);
         intent.putExtra(KEY_POSID, posId);
         intent.putExtra(KEY_LOGO, logo);
+        intent.putExtra(KEY_FETCH_DELAY, fetchDelay);
         activity.startActivity(intent);
         result.success(true);
     }

--- a/android/src/main/java/com/zero/flutter_qq_ads/page/AdSplashActivity.java
+++ b/android/src/main/java/com/zero/flutter_qq_ads/page/AdSplashActivity.java
@@ -55,8 +55,9 @@ public class AdSplashActivity extends AppCompatActivity implements SplashADListe
         // 获取参数
         posId = getIntent().getStringExtra(PluginDelegate.KEY_POSID);
         String logo = getIntent().getStringExtra(PluginDelegate.KEY_LOGO);
+        int fetchDelay = getIntent().getIntExtra(PluginDelegate.KEY_FETCH_DELAY,0);
         // 创建开屏广告
-        SplashAD splashAD = new SplashAD(this, posId, this, 0);
+        SplashAD splashAD = new SplashAD(this, posId, this, fetchDelay);
         if (TextUtils.isEmpty(logo)) {
             // logo 为空则加载全屏广告
             ad_logo.setVisibility(View.GONE);

--- a/android/src/main/java/com/zero/flutter_qq_ads/page/AdSplashActivity.java
+++ b/android/src/main/java/com/zero/flutter_qq_ads/page/AdSplashActivity.java
@@ -55,9 +55,10 @@ public class AdSplashActivity extends AppCompatActivity implements SplashADListe
         // 获取参数
         posId = getIntent().getStringExtra(PluginDelegate.KEY_POSID);
         String logo = getIntent().getStringExtra(PluginDelegate.KEY_LOGO);
-        int fetchDelay = getIntent().getIntExtra(PluginDelegate.KEY_FETCH_DELAY,0);
+        double fetchDelay = getIntent().getDoubleExtra(PluginDelegate.KEY_FETCH_DELAY,0);
+        int absFetchDelay= (int) (fetchDelay*1000);
         // 创建开屏广告
-        SplashAD splashAD = new SplashAD(this, posId, this, fetchDelay);
+        SplashAD splashAD = new SplashAD(this, posId, this, absFetchDelay);
         if (TextUtils.isEmpty(logo)) {
             // logo 为空则加载全屏广告
             ad_logo.setVisibility(View.GONE);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -206,7 +206,11 @@ Future<bool> init() async {
 /// [logo] 展示如果传递则展示logo，不传递不展示
 Future<void> showSplashAd([String logo]) async {
   try {
-    bool result = await FlutterQqAds.showSplashAd(AdsConfig.splashId, logo);
+    bool result = await FlutterQqAds.showSplashAd(
+      AdsConfig.splashId,
+      logo: logo,
+      fetchDelay: 3,
+    );
     _result = "展示开屏广告${result ? '成功' : '失败'}";
   } on PlatformException catch (e) {
     _result = "展示开屏广告失败 code:${e.code} msg:${e.message} details:${e.details}";

--- a/ios/Classes/Page/SplashPage.m
+++ b/ios/Classes/Page/SplashPage.m
@@ -18,11 +18,14 @@
 // 加载广告
 -(void)loadAd:(FlutterMethodCall *)call{
     NSString* logo=call.arguments[@"logo"];
+    int fetchDelay=[call.arguments[@"fetchDelay"] intValue];
     // logo 判断为空，则全屏展示
     self.fullScreenAd=[logo isKindOfClass:[NSNull class]]||[logo length]==0;
     // 初始化开屏广告
     self.splashAd=[[GDTSplashAd alloc] initWithPlacementId:self.posId];
     self.splashAd.delegate=self;
+    // 设置超时时长
+    self.splashAd.fetchDelay=fetchDelay;
     // 加载全屏广告
     if(self.fullScreenAd){
         [self.splashAd loadFullScreenAd];

--- a/lib/flutter_qq_ads.dart
+++ b/lib/flutter_qq_ads.dart
@@ -35,12 +35,15 @@ class FlutterQqAds {
   /// 展示开屏广告
   /// [posId] 广告位 id
   /// [logo] 如果传值则展示底部logo，不传不展示，则全屏展示
-  static Future<bool> showSplashAd(String posId, [String logo]) async {
+  /// [fetchDelay] 拉取广告的超时时间，默认值 3 秒
+  static Future<bool> showSplashAd(String posId,
+      {String logo, int fetchDelay = 3}) async {
     final bool result = await _methodChannel.invokeMethod(
       'showSplashAd',
       {
         'posId': posId,
         'logo': logo,
+        'fetchDelay': fetchDelay,
       },
     );
     return result;

--- a/lib/flutter_qq_ads.dart
+++ b/lib/flutter_qq_ads.dart
@@ -35,9 +35,9 @@ class FlutterQqAds {
   /// 展示开屏广告
   /// [posId] 广告位 id
   /// [logo] 如果传值则展示底部logo，不传不展示，则全屏展示
-  /// [fetchDelay] 拉取广告的超时时间，默认值 3 秒
+  /// [fetchDelay] 拉取广告的超时时间，默认值 3 秒，取值范围[1.5~5]秒
   static Future<bool> showSplashAd(String posId,
-      {String logo, int fetchDelay = 3}) async {
+      {String logo, double fetchDelay = 3}) async {
     final bool result = await _methodChannel.invokeMethod(
       'showSplashAd',
       {

--- a/test/ads_config.dart
+++ b/test/ads_config.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+/// 广告配置信息
+class AdsConfig {
+  /// 获取 Logo 资源名称
+  static String get logo {
+    if (Platform.isAndroid) {
+      return 'flutterads_logo';
+    } else {
+      return 'LaunchImage';
+    }
+  }
+
+  /// 获取 Logo 资源名称 2
+  static String get logo2 {
+    if (Platform.isAndroid) {
+      return 'flutterads_logo2';
+    } else {
+      return 'LaunchImage2';
+    }
+  }
+
+  /// 获取 App id
+  static String get appId {
+    // 官方 demo id
+    // com.qq.gdt.GDTMobSample
+    // return '1105344611';
+    // com.banjixiaoguanjia.app
+    if (Platform.isAndroid) {
+      return '1200012024';
+    } else {
+      return '1200018693';
+    }
+  }
+
+  /// 获取开屏广告位id
+  static String get splashId {
+    // 官方demo
+    // return "9040714184494018";
+    if (Platform.isAndroid) {
+      return '8022311121246224';
+    } else {
+      return '5052818319908354';
+    }
+  }
+
+  /// 获取插屏广告位id
+  static String get interstitialId {
+    // 官方demo
+    // return "9040714184494018";
+    if (Platform.isAndroid) {
+      return '3022327103988804';
+    } else {
+      return '5092321153081845';
+    }
+  }
+
+  /// 获取插屏全屏视频广告位id
+  static String get interstitialFullScreenVideoId {
+    // 官方demo
+    // return "9040714184494018";
+    if (Platform.isAndroid) {
+      return '3012521499614895';
+    } else {
+      return '3092322459911886';
+    }
+  }
+
+  /// 获取插屏激励视频广告位id
+  static String get interstitialRewardVideoId {
+    // 官方demo
+    // return "9040714184494018";
+    if (Platform.isAndroid) {
+      return '2052820580637311';
+    } else {
+      return '9022927550132316';
+    }
+  }
+
+  /// 获取激励视频广告位id
+  static String get rewardVideoId {
+    // 官方demo
+    // return "9040714184494018";
+    if (Platform.isAndroid) {
+      return '3032129193181886';
+    } else {
+      return '1042528123383807';
+    }
+  }
+}

--- a/test/flutter_qq_ads_test.dart
+++ b/test/flutter_qq_ads_test.dart
@@ -2,14 +2,30 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_qq_ads/flutter_qq_ads.dart';
 
+import 'ads_config.dart';
+
 void main() {
   const MethodChannel channel = MethodChannel('flutter_qq_ads');
 
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      return '42';
+    channel.setMockMethodCallHandler((MethodCall call) async {
+      String method = call.method;
+      if (method == 'initAd') {
+        String appId = call.arguments['appId'] ?? '';
+        return appId.isNotEmpty;
+      } else if (method == 'showSplashAd') {
+        String posId = call.arguments['posId'] ?? '';
+        return posId.isNotEmpty;
+      } else if (method == 'showInterstitialAd') {
+        String posId = call.arguments['posId'] ?? '';
+        return posId.isNotEmpty;
+      } else if (method == 'showRewardVideoAd') {
+        String posId = call.arguments['posId'] ?? '';
+        return posId.isNotEmpty;
+      }
+      return false;
     });
   });
 
@@ -17,7 +33,25 @@ void main() {
     channel.setMockMethodCallHandler(null);
   });
 
-  test('getPlatformVersion', () async {
-    expect(await FlutterQqAds.platformVersion, '42');
+  test('initAd', () async {
+    expect(await FlutterQqAds.initAd(AdsConfig.appId), true);
+  });
+  test('showSplashAd', () async {
+    expect(await FlutterQqAds.showSplashAd(AdsConfig.splashId), true);
+  });
+  test('showInterstitialAd', () async {
+    expect(
+        await FlutterQqAds.showInterstitialAd(AdsConfig.interstitialId), true);
+    expect(
+        await FlutterQqAds.showInterstitialAd(
+            AdsConfig.interstitialFullScreenVideoId),
+        true);
+    expect(
+        await FlutterQqAds.showInterstitialAd(
+            AdsConfig.interstitialRewardVideoId),
+        true);
+  });
+  test('showRewardVideoAd', () async {
+    expect(await FlutterQqAds.showRewardVideoAd(AdsConfig.rewardVideoId), true);
   });
 }


### PR DESCRIPTION
- 本次添加了超时时间设置 `fetchDelay` ，在Flutter 接口上统一时间为秒，iOS 原生端为秒，Android 原生端转换为毫秒。
- 本次接口有较大变化，logo 参数由位置参数变为可选命名参数，API 发生轻微变化，请更新适配即可，操作如下。
### 原本调用
``` Dart
FlutterQqAds.showSplashAd(posId, 'flutterads_logo');
```
### 现在调用
``` Dart
FlutterQqAds.showSplashAd(posId,logo:'flutterads_logo');
```
